### PR TITLE
Merge the pact-crypto lib to the main tree

### DIFF
--- a/pact-repl/Pact/Core/IR/Eval/Direct/CoreBuiltin.hs
+++ b/pact-repl/Pact/Core/IR/Eval/Direct/CoreBuiltin.hs
@@ -44,10 +44,7 @@ import qualified Data.List as L
 import System.Clock
 #endif
 
-#ifndef WITHOUT_CRYPTO
 import qualified Control.Lens as Lens
-#endif
-
 import qualified Data.Vector.Algorithms.Intro as V
 import qualified Data.Char as Char
 import qualified Data.ByteString as BS
@@ -62,6 +59,7 @@ import Pact.Core.Type
 import Pact.Core.Errors
 import Pact.Core.PactValue
 import Pact.Core.Hash
+import Pact.Core.Base64
 import Pact.Core.Persistence
 import Pact.Core.Guards
 import Pact.Core.Capabilities
@@ -80,11 +78,9 @@ import qualified Data.Binary.Put as Bin
 
 
 import Pact.Core.Namespace
-#ifndef WITHOUT_CRYPTO
-import Pact.Core.Crypto.Pairing
-import Pact.Core.Crypto.Hash.Poseidon
-import Pact.Core.Crypto.Hash.Keccak256
-#endif
+import Pact.Crypto.Pairing
+import Pact.Crypto.Hash.Poseidon
+import Pact.Crypto.Hash.Keccak256
 import Pact.Core.SizeOf
 
 
@@ -1772,7 +1768,6 @@ coreChainData info b _env = \case
 -- ZK defns
 -- -------------------------
 
-#ifndef WITHOUT_CRYPTO
 ensureOnCurve :: (Num p, Eq p) => i -> CurvePoint p -> p -> EvalM e b i ()
 ensureOnCurve info p bp = unless (isOnCurve p bp) $ throwExecutionError info PointNotOnCurve
 
@@ -1920,26 +1915,6 @@ coreHashKeccak256 info b _env = \case
           Right output -> pure output
     return (VString output)
   args -> argsError info b args
-
-
-#else
-
-zkPairingCheck :: (IsBuiltin b) => NativeFunction e b i
-zkPairingCheck info _b _env _args = throwExecutionError info $ EvalError $ "crypto disabled"
-
-zkScalarMult :: (IsBuiltin b) => NativeFunction e b i
-zkScalarMult info _b _env _args = throwExecutionError info $ EvalError $ "crypto disabled"
-
-zkPointAddition :: (IsBuiltin b) => NativeFunction e b i
-zkPointAddition info _b _env _args = throwExecutionError info $ EvalError $ "crypto disabled"
-
-poseidonHash :: (IsBuiltin b) => NativeFunction e b i
-poseidonHash info _b _env _args = throwExecutionError info $ EvalError $ "crypto disabled"
-
-coreHashKeccak256 :: (IsBuiltin b) => NativeFunction e b i
-coreHashKeccak256 info _b _env _args = throwExecutionError info $ EvalError $ "crypto disabled"
-
-#endif
 
 -----------------------------------
 -- SPV

--- a/pact-repl/Pact/Core/IR/Eval/Direct/ReplBuiltin.hs
+++ b/pact-repl/Pact/Core/IR/Eval/Direct/ReplBuiltin.hs
@@ -23,6 +23,7 @@ import qualified Data.Vector as V
 import Pact.Core.Builtin
 import Pact.Core.Literal
 import Pact.Core.Hash
+import Pact.Core.Base64
 import Pact.Core.IR.Eval.Runtime
 import Pact.Core.DefPacts.Types
 import Pact.Core.IR.Eval.Direct.Evaluator

--- a/pact-repl/Pact/Core/Repl/Runtime/ReplBuiltin.hs
+++ b/pact-repl/Pact/Core/Repl/Runtime/ReplBuiltin.hs
@@ -23,6 +23,7 @@ import qualified Data.Vector as V
 import Pact.Core.Builtin
 import Pact.Core.Literal
 import Pact.Core.Hash
+import Pact.Core.Base64
 import Pact.Core.IR.Eval.Runtime
 import Pact.Core.DefPacts.Types
 import Pact.Core.IR.Eval.CEK.CoreBuiltin

--- a/pact-request-api/Pact/Core/Command/Util.hs
+++ b/pact-request-api/Pact/Core/Command/Util.hs
@@ -42,7 +42,7 @@ import Data.Hashable (Hashable)
 import Data.Text (Text)
 import Data.Text.Encoding
 
-import Pact.Core.Hash
+import Pact.Core.Base64
 import qualified Pact.JSON.Encode as J
 
 resultToEither :: Result a -> Either String a

--- a/pact-tests/Pact/Core/Test/Keccak256Tests.hs
+++ b/pact-tests/Pact/Core/Test/Keccak256Tests.hs
@@ -8,8 +8,8 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.Vector qualified as V
-import Pact.Core.Crypto.Base64 (decodeBase64UrlUnpadded, encodeBase64UrlUnpadded)
-import Pact.Core.Crypto.Hash.Keccak256 (keccak256)
+import Pact.Core.Base64 (decodeBase64UrlUnpadded, encodeBase64UrlUnpadded)
+import Pact.Crypto.Hash.Keccak256 (keccak256)
 import Test.Tasty
 import Test.Tasty.HUnit
 

--- a/pact-tests/Pact/Core/Test/PoseidonTests.hs
+++ b/pact-tests/Pact/Core/Test/PoseidonTests.hs
@@ -3,7 +3,7 @@ module Pact.Core.Test.PoseidonTests(tests) where
 
 import Test.Tasty
 import Test.Tasty.HUnit
-import Pact.Core.Crypto.Hash.Poseidon
+import Pact.Crypto.Hash.Poseidon
 
 tests :: TestTree
 tests = testGroup "poseidon" $ pure $

--- a/pact-tests/Pact/Core/Test/ZkTests.hs
+++ b/pact-tests/Pact/Core/Test/ZkTests.hs
@@ -10,8 +10,8 @@ import Data.Field(Field)
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import Pact.Core.Crypto.Pairing.Fields
-import Pact.Core.Crypto.Pairing
+import Pact.Crypto.Pairing.Fields
+import Pact.Crypto.Pairing
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.Hedgehog
@@ -330,4 +330,3 @@ verify inp p = let
     , (_alfa1 solVerifyingKey, _beta2 solVerifyingKey)
     , (vk_x', _gamma2 solVerifyingKey)
     , (_proofC p, _delta2 solVerifyingKey)]
-

--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -26,11 +26,6 @@ extra-source-files:
     cbits/musl/sqrt_data.h
     docs/builtins/**/*.md
 
-flag with-crypto
-  description: Enable crypto primitives
-  manual: True
-  default: True
-
 flag with-funcall-tracing
   description: Enable Tracing on user function calls
   manual: True
@@ -68,6 +63,7 @@ common pact-common
     , exceptions
     , filepath
     , hashable
+    , hashes >= 0.3
     , lens
     , mtl
     , pact-json
@@ -107,6 +103,10 @@ common pact-common
     , ethereum
     , template-haskell
     , pact-tng:unsafe
+    -- ZK deps
+    , mod
+    , poly
+    , groups
 
   ghc-options: -Wall -Werror -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   ghc-prof-options: -fprof-auto -fprof-auto-calls
@@ -125,35 +125,6 @@ common pact-common
     NumericUnderscores
     TypeOperators
 
--- internal crypto lirbary
-library pact-crypto
-  default-language: Haskell2010
-  hs-source-dirs: crypto
-  build-depends:
-      poly
-    , mod
-    , primitive
-    , groups
-    , base
-    , semirings
-    , deepseq
-    , vector
-    , text
-    , base64-bytestring
-    , bytestring
-    , hashes >= 0.3
-    , safe-exceptions
-    , deepseq
-
-  exposed-modules:
-    Pact.Core.Crypto.Base64
-    Pact.Core.Crypto.Hash.Poseidon
-    Pact.Core.Crypto.Hash.Keccak256
-    Pact.Core.Crypto.Pairing
-    Pact.Core.Crypto.Pairing.Fields
-  if !(flag(with-crypto))
-    buildable: False
-
 library pact-request-api
   import: pact-common
   visibility: public
@@ -163,7 +134,6 @@ library pact-request-api
     , asn1-types
     , cereal
     , pact-tng
-    , pact-tng:pact-crypto
     , yaml
     , lrucaching
     , servant-server
@@ -193,11 +163,6 @@ library
   import: pact-common
   hs-source-dirs: pact
 
-  if (flag(with-crypto))
-    build-depends: pact-tng:pact-crypto
-  else
-    cpp-options: -DWITHOUT_CRYPTO
-
   build-tool-depends:
     , alex:alex
     , happy:happy
@@ -213,6 +178,7 @@ library
     Pact.Core.Builtin
     Pact.Core.Names
     Pact.Core.Literal
+    Pact.Core.Base64
     Pact.Core.Guards
     Pact.Core.Imports
     Pact.Core.DefPacts.Types
@@ -287,6 +253,13 @@ library
     Pact.Core.Serialise.LegacyPact.Types
     Pact.Core.Serialise.CBOR_V1
 
+    Pact.Crypto.Hash.Poseidon
+    Pact.Crypto.Hash.Keccak256
+
+    -- ZK
+    Pact.Crypto.Pairing
+    Pact.Crypto.Pairing.Fields
+
     -- WebAuthn
     Pact.Crypto.WebAuthn.Cose.PublicKey
     Pact.Crypto.WebAuthn.Cose.PublicKeyWithSignAlg
@@ -305,11 +278,6 @@ library pact-repl
   import: pact-common
   hs-source-dirs: pact-repl
   visibility: public
-
-  if (flag(with-crypto))
-    build-depends: pact-tng:pact-crypto
-  else
-    cpp-options: -DWITHOUT_CRYPTO
 
   if (flag(with-funcall-tracing))
     cpp-options: -DWITH_FUNCALL_TRACING
@@ -342,7 +310,6 @@ library pact-repl
 
   build-depends:
     , pact-tng
-    , pact-tng:pact-crypto
     , filepath
     , pandoc
 
@@ -611,5 +578,3 @@ test-suite core-tests
     , Pact.Core.Test.TransitiveDependencyTests
     , Pact.Core.Test.ReplTestUtils
     , Pact.Core.Test.TypecheckerTests
-  if (flag(with-crypto))
-    build-depends: pact-tng:pact-crypto

--- a/pact/Pact/Core/Base64.hs
+++ b/pact/Pact/Core/Base64.hs
@@ -1,4 +1,4 @@
-module Pact.Core.Crypto.Base64
+module Pact.Core.Base64
   ( encodeBase64UrlUnpadded
   , decodeBase64UrlUnpadded
   , fromB64UrlUnpaddedText
@@ -12,8 +12,7 @@ import Data.ByteString (ByteString)
 
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Base64.URL as B64URL
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
+import qualified Data.Text.Encoding as TE
 
 equalWord8 :: Word8
 equalWord8 = toEnum $ fromEnum '='
@@ -23,7 +22,7 @@ decodeBase64UrlUnpadded = B64URL.decode
 
 fromB64UrlUnpaddedText :: ByteString -> Either String Text
 fromB64UrlUnpaddedText bs = case decodeBase64UrlUnpadded bs of
-  Right bs' -> case T.decodeUtf8' bs' of
+  Right bs' -> case TE.decodeUtf8' bs' of
     Left _ -> Left "Base64URL decode failed: invalid unicode"
     Right t -> Right t
   Left _ -> Left $ "Base64URL decode failed"

--- a/pact/Pact/Core/Errors.hs
+++ b/pact/Pact/Core/Errors.hs
@@ -225,7 +225,7 @@ import Pact.Core.DeriveConTag
 import Pact.Core.ChainData (ChainId(_chainId))
 import Data.String (IsString(..))
 import Pact.Core.Gas.Types
-import Pact.Core.Crypto.Hash.Keccak256
+import Pact.Crypto.Hash.Keccak256
 import qualified Text.Megaparsec as MP
 import qualified Text.Megaparsec.Char as MP
 import Text.Read (readMaybe)

--- a/pact/Pact/Core/Hash.hs
+++ b/pact/Pact/Core/Hash.hs
@@ -22,10 +22,6 @@ module Pact.Core.Hash
 , pactHash
 , pactInitialHash
 , pactHashLength
-, encodeBase64UrlUnpadded
-, decodeBase64UrlUnpadded
-, toB64UrlUnpaddedText
-, fromB64UrlUnpaddedText
 , defaultPactHash
 , placeholderHash
 , moduleHashToText
@@ -44,7 +40,7 @@ import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8)
 import GHC.Generics
 
-import Pact.Core.Crypto.Base64
+import Pact.Core.Base64
 
 import qualified Data.ByteString as B
 import qualified Data.Text as T

--- a/pact/Pact/Core/IR/Eval/CEK/CoreBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/CoreBuiltin.hs
@@ -48,14 +48,13 @@ import qualified GHC.Exts as Exts
 import qualified GHC.Integer.Logarithms as IntLog
 import qualified Pact.Time as PactTime
 import qualified Pact.Core.Trans.MPFR as MPFR
-#ifndef WITHOUT_CRYPTO
 import qualified Control.Lens as Lens
-#endif
 
 import Pact.Core.Builtin
 import Pact.Core.Literal
 import Pact.Core.Errors
 import Pact.Core.Hash
+import Pact.Core.Base64
 import Pact.Core.Names
 import Pact.Core.Guards
 import Pact.Core.PactValue
@@ -68,11 +67,9 @@ import Pact.Core.Gas
 import Pact.Core.Type
 import Pact.Core.ModRefs
 import Pact.Core.Info
-#ifndef WITHOUT_CRYPTO
-import Pact.Core.Crypto.Pairing
-import Pact.Core.Crypto.Hash.Poseidon
-import Pact.Core.Crypto.Hash.Keccak256
-#endif
+import Pact.Crypto.Pairing
+import Pact.Crypto.Hash.Poseidon
+import Pact.Crypto.Hash.Keccak256
 import Pact.Crypto.Hyperlane
 
 import Pact.Core.IR.Term
@@ -1776,7 +1773,6 @@ coreChainData info b cont handler _env = \case
 -- ZK defns
 -- -------------------------
 
-#ifndef WITHOUT_CRYPTO
 ensureOnCurve :: (Num p, Eq p) => i -> CurvePoint p -> p -> EvalM e b i ()
 ensureOnCurve info p bp = unless (isOnCurve p bp) $ throwExecutionError info PointNotOnCurve
 
@@ -1926,25 +1922,6 @@ coreHashKeccak256 info b cont handler _env = \case
           Right output -> pure output
     returnCEKValue cont handler (VString output)
   args -> argsError info b args
-
-#else
-
-zkPairingCheck :: NativeFunction e b i
-zkPairingCheck info _b _cont _handler _env _args = throwExecutionError info $ EvalError $ "crypto disabled"
-
-zkScalarMult :: NativeFunction e b i
-zkScalarMult info _b _cont _handler _env _args = throwExecutionError info $ EvalError $ "crypto disabled"
-
-zkPointAddition :: NativeFunction e b i
-zkPointAddition info _b _cont _handler _env _args = throwExecutionError info $ EvalError $ "crypto disabled"
-
-poseidonHash :: NativeFunction e b i
-poseidonHash info _b _cont _handler _env _args = throwExecutionError info $ EvalError $ "crypto disabled"
-
-coreHashKeccak256 :: NativeFunction e b i
-coreHashKeccak256 info _b _cont _handler _env _args = throwExecutionError info $ EvalError $ "crypto disabled"
-
-#endif
 
 -----------------------------------
 -- SPV

--- a/pact/Pact/Core/Names.hs
+++ b/pact/Pact/Core/Names.hs
@@ -97,6 +97,7 @@ import qualified Text.Megaparsec.Char as MP
 import qualified Pact.JSON.Encode as J
 
 import Pact.Core.Hash
+import Pact.Core.Base64
 import Pact.Core.Pretty hiding (dot)
 import qualified Data.Text.Encoding as T
 import qualified Data.ByteString.Short as SB

--- a/pact/Pact/Core/Serialise/LegacyPact/Types.hs
+++ b/pact/Pact/Core/Serialise/LegacyPact/Types.hs
@@ -36,7 +36,6 @@ import qualified Data.Vector as V
 import qualified Data.Attoparsec.Text as AP
 import Data.Decimal (Decimal)
 import Pact.Time
-import qualified Pact.Core.Hash as PC
 
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Key as A
@@ -47,7 +46,7 @@ import Pact.JSON.Legacy.Hashable
 import Data.String (IsString, fromString)
 import Data.List (sort)
 import Text.Trifecta (ident,TokenParsing,(<?>),dot, alphaNum, between, char, CharParsing, IdentifierStyle(..), letter,  digit, oneOf)
-import Pact.Core.Hash (decodeBase64UrlUnpadded)
+import Pact.Core.Base64 (decodeBase64UrlUnpadded)
 import Text.Parser.Token.Highlight
 import Data.Hashable
 import Control.Applicative
@@ -223,13 +222,13 @@ newtype Hash = Hash { unHash :: ShortByteString }
   deriving (Eq, Ord, Generic, Hashable,LegacyHashable, Show)
 
 instance JD.FromJSON Hash where
-  parseJSON = JD.withText "Hash" $ \t -> case PC.decodeBase64UrlUnpadded (T.encodeUtf8 t) of
+  parseJSON = JD.withText "Hash" $ \t -> case decodeBase64UrlUnpadded (T.encodeUtf8 t) of
     Left _ -> fail "cant decode"
     Right t' -> pure (Hash $ toShort t')
 
 instance JD.FromJSONKey Hash where
     fromJSONKey = JD.FromJSONKeyTextParser $ \t ->
-      case PC.decodeBase64UrlUnpadded (T.encodeUtf8 t) of
+      case decodeBase64UrlUnpadded (T.encodeUtf8 t) of
         Left _ -> fail "cant decode"
         Right t' -> pure (Hash $ toShort t')
 

--- a/pact/Pact/Crypto/Hash/Keccak256.hs
+++ b/pact/Pact/Crypto/Hash/Keccak256.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 -- | Implementation of the `keccak256` pact native.
-module Pact.Core.Crypto.Hash.Keccak256 (Keccak256Error(..), keccak256) where
+module Pact.Crypto.Hash.Keccak256 (Keccak256Error(..), keccak256) where
 
 import Control.Exception (Exception(..), SomeException(..))
 import Control.Monad (forM_)
@@ -24,7 +24,7 @@ import Data.Hash.Keccak (Keccak256(..))
 import Data.Text (Text)
 import Data.Text.Encoding qualified as Text
 import Data.Vector (Vector)
-import Pact.Core.Crypto.Base64 (encodeBase64UrlUnpadded, decodeBase64UrlUnpadded)
+import Pact.Core.Base64 (encodeBase64UrlUnpadded, decodeBase64UrlUnpadded)
 import GHC.Generics(Generic)
 import System.IO.Unsafe (unsafePerformIO)
 
@@ -45,8 +45,8 @@ keccak256 bytesArray = unsafePerformIO $ do
       case decodeBase64UrlUnpadded bytes of
         Left b64Err -> do
           throwM (Keccak256Base64Exception b64Err)
-        Right bytes -> do
-          updateByteString @Keccak256 ctx bytes
+        Right decodedBytes -> do
+          updateByteString @Keccak256 ctx decodedBytes
     Keccak256 hash <- finalize ctx
     pure (BSS.fromShort $ coerce hash)
   case e of

--- a/pact/Pact/Crypto/Hash/Poseidon.hs
+++ b/pact/Pact/Crypto/Hash/Poseidon.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE CPP #-}
 
-module Pact.Core.Crypto.Hash.Poseidon (poseidon) where
+module Pact.Crypto.Hash.Poseidon (poseidon) where
 
 import qualified Data.Primitive.Array as Array
 import qualified Data.Primitive.SmallArray as SmallArray

--- a/pact/Pact/Crypto/Hyperlane.hs
+++ b/pact/Pact/Crypto/Hyperlane.hs
@@ -47,13 +47,13 @@ import Data.WideWord.Word256 (Word256(..))
 import Data.Word (Word8, Word16, Word32)
 import Ethereum.Misc (keccak256, _getKeccak256Hash, _getBytesN)
 import Pact.JSON.Decode qualified as J
-import Pact.Core.StableEncoding 
+import Pact.Core.StableEncoding
 
 import Pact.Core.Errors
 import Pact.Core.PactValue
 import Pact.Core.Names
 import Pact.Core.Literal
-import Pact.Core.Hash
+import Pact.Core.Base64
 import qualified Data.Map as M
 
 ----------------------------------------------

--- a/pact/Pact/Crypto/Pairing.hs
+++ b/pact/Pact/Crypto/Pairing.hs
@@ -21,7 +21,7 @@
 {-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
-module Pact.Core.Crypto.Pairing
+module Pact.Crypto.Pairing
   ( pairing
   , CurvePoint(..)
   , Fq(..)
@@ -79,7 +79,7 @@ import Control.DeepSeq (NFData)
 
 -- import Pact.Core.Literal
 -- import Pact.Core.PactValue
-import Pact.Core.Crypto.Pairing.Fields
+import Pact.Crypto.Pairing.Fields
 
 -- import qualified Pact.Core.Names as Name
 

--- a/pact/Pact/Crypto/Pairing/Fields.hs
+++ b/pact/Pact/Crypto/Pairing/Fields.hs
@@ -10,7 +10,7 @@
 -- Maintainer: Lars Kuhtz <lars@kadena.io>
 -- Stability: experimental
 --
-module Pact.Core.Crypto.Pairing.Fields
+module Pact.Crypto.Pairing.Fields
 ( GaloisField(..)
 , Fq(..)
 ) where
@@ -78,4 +78,3 @@ instance GaloisField Fq where
   degree _ = 1
 
   frobenius = id
-


### PR DESCRIPTION
I've merged the the pact-cypto lib into the main tree, moving everything from Pact.Core.Crypto -> to Pact.Crypto (like the WebAuthn implementation).
Base64 has been moved moved to the directly Pact.Core, and indirect import through Pact.Hash removed.

Preprocessor directive WITHOUT_CRYPTO (and related cases) have been removed.

A warning (shadowed variable) has been fixed in  Keccak.

I hope you like the color of bicycle shed @jmcardon  .. :smiley: