### PR TITLE
Export more types from pact-request-api

### DIFF
--- a/pact-request-api/Pact/Core/Command/Client.hs
+++ b/pact-request-api/Pact/Core/Command/Client.hs
@@ -14,6 +14,7 @@ module Pact.Core.Command.Client (
   ApiSigner(..),
   ApiPublicMeta(..),
   ApiReq(..),
+  PactValue(..),
   AddSigsReq(..),
   mkKeyPairs,
   apiReq,
@@ -25,6 +26,7 @@ module Pact.Core.Command.Client (
   mkExec,
   mkCont,
   addSigsReq,
+  SigCapability,
   combineSigs,
   combineSigDatas,
   signCmd,
@@ -76,13 +78,9 @@ import Pact.Core.Command.Util
 import Pact.Core.Command.Crypto
 import Pact.Core.Guards
 import Pact.Core.PactValue
-import Pact.Core.Names
-import Pact.Core.Verifiers
-import Pact.Core.StableEncoding
 import Pact.Core.Gas
 import Pact.Core.Hash
 import Pact.Core.SPV
-import Pact.Core.Signer
 import qualified Pact.Core.Hash as PactHash
 import Pact.Core.Command.SigData
 import Pact.Core.Pretty (renderCompactString)

--- a/pact-request-api/Pact/Core/Command/Server.hs
+++ b/pact-request-api/Pact/Core/Command/Server.hs
@@ -63,7 +63,6 @@ import Pact.Core.Hash
 import Pact.Core.Namespace
 import Pact.Core.Persistence.Types
 import Pact.Core.SPV
-import Pact.Core.StableEncoding
 import qualified Pact.Core.Version as PI
 import qualified Pact.JSON.Decode as JD
 import qualified Pact.JSON.Encode as JE

--- a/pact-request-api/Pact/Core/Command/SigData.hs
+++ b/pact-request-api/Pact/Core/Command/SigData.hs
@@ -37,7 +37,6 @@ import Pact.Core.Command.Types
 import qualified Pact.JSON.Encode as J
 
 import qualified Pact.JSON.Legacy.HashMap as LHM
-import Pact.Core.Hash
 import Data.Maybe (catMaybes)
 import Pact.Core.Command.Util
 import Data.Bifunctor (first)

--- a/pact-request-api/Pact/Core/Command/Types.hs
+++ b/pact-request-api/Pact/Core/Command/Types.hs
@@ -30,6 +30,11 @@
 
 module Pact.Core.Command.Types
   ( Command(..),cmdPayload,cmdSigs,cmdHash
+  , PactHash.Hash
+  , PactHash.parseHash
+  , PactHash.hash
+  , PublicMeta(..)
+  , StableEncoding(..)
   , verifyUserSig
   , verifyUserSigs
   , verifyCommand
@@ -42,6 +47,17 @@ module Pact.Core.Command.Types
   , Signer(..),siScheme, siPubKey, siAddress, siCapList
   , UserSig(..)
   , PactResult(..)
+  , SigCapability(..)
+  , CapToken(..)
+  , QualifiedName(..)
+  , PublicKeyText(..)
+  , DefPactId(..)
+  , Verifier
+  , ParsedVerifierProof
+  , ChainId
+  , GasLimit
+  , TTLSeconds
+  , NetworkId
   , _PactResultOk
   , _PactResultErr
   , CommandResult(..),crReqKey,crTxId,crResult,crGas,crLogs,crEvents
@@ -79,6 +95,7 @@ import Pact.Core.Capabilities
 import Pact.Core.ChainData
 import Pact.Core.DefPacts.Types
 import Pact.Core.Guards
+import Pact.Core.Names
 import Pact.Core.Gas.Types
 import qualified Pact.Core.Hash as PactHash
 import Pact.Core.Persistence.Types

--- a/pact-tests/Pact/Core/Test/PactContinuationTest.hs
+++ b/pact-tests/Pact/Core/Test/PactContinuationTest.hs
@@ -37,8 +37,6 @@ import Pact.Core.Command.Types
 import Pact.Core.Environment.Types
 import Pact.Core.Errors
 import Pact.Core.SPV
-import Pact.Core.StableEncoding
-import Pact.Core.Signer
 import Pact.Core.PactValue
 import Pact.Core.DefPacts.Types
 import Pact.Core.Command.Util

--- a/pact-tests/Pact/Core/Test/PactServerTests.hs
+++ b/pact-tests/Pact/Core/Test/PactServerTests.hs
@@ -35,12 +35,10 @@ import Pact.Core.Command.Types
 import Pact.Core.Command.Util
 import Pact.Core.Command.Server.History
 import Pact.Core.Hash
-import Pact.Core.Names
 import Pact.Core.PactValue
 import Pact.Core.Persistence.SQLite
 import Pact.Core.SPV (noSPVSupport)
 import Pact.Core.Serialise
-import Pact.Core.StableEncoding
 import qualified Pact.JSON.Encode as J
 import Servant.API
 import Servant.Client

--- a/pact-tests/Pact/Core/Test/SignatureSchemeTests.hs
+++ b/pact-tests/Pact/Core/Test/SignatureSchemeTests.hs
@@ -21,10 +21,8 @@ import Pact.Core.Command.Crypto
 import Pact.Core.Command.Client
 import qualified Pact.JSON.Encode as J
 import Pact.Core.PactValue
-import Pact.Core.Hash
 import Pact.Core.Command.RPC
 import Pact.Core.Command.Util
-import Pact.Core.Signer
 
 
 ---- HELPER DATA TYPES AND FUNCTIONS ----


### PR DESCRIPTION
Add some missing exported types, to allow:
- https://github.com/kda-community/signing-api
- https://github.com/kda-community/kda-tool

to build against Pact-5