### PR TITLE
Fix gasmodel bench

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -1,9 +1,18 @@
 
-name: Build and publish and optionnaly Release
+name: Build / Release / Benchamrk
 
+# Build on each commit
+# Gasmodel and release must be manually selected.
 on:
   workflow_dispatch:
     inputs:
+
+      gasmodel:
+          description: "Run Gasmodel"
+          type: boolean
+          required: true
+          default: false
+
       release:
           description: "Create a github release"
           type: boolean
@@ -171,10 +180,11 @@ jobs:
 
         OUTPUT_DIR=artifacts/pact
         mkdir -p $OUTPUT_DIR
+        mkdir -p $OUTPUT_DIR/gasmodel/contracts/
         cp $(cabal list-bin pact) $OUTPUT_DIR
         cp $(cabal list-bin profile-tx) $OUTPUT_DIR
         cp $(cabal list-bin core-tests) $OUTPUT_DIR
-        cp $(cabal list-bin gasmodel) $OUTPUT_DIR
+        cp $(cabal list-bin gasmodel) $OUTPUT_DIR/run_gasmodel
         cp CHANGELOG.md $OUTPUT_DIR
         cp README.md $OUTPUT_DIR
         cp LICENSE $OUTPUT_DIR
@@ -182,6 +192,7 @@ jobs:
         cp cabal.project artifacts/pact
         cp cabal.project.local artifacts/pact
         cp cabal.project.freeze artifacts/pact
+        cp gasmodel/contracts/coin-v5-create.pact $OUTPUT_DIR/gasmodel/contracts/
 
         OUTPUT_DIR=artifacts/pact_to_release
         mkdir -p $OUTPUT_DIR
@@ -280,3 +291,52 @@ jobs:
           allowUpdates: true
           replacesArtifacts: true
           updateOnlyUnreleased: true
+
+  gasmodel:
+    runs-on: "ubuntu-24.04"
+    needs: build
+    if: inputs.gasmodel == true
+
+    env:
+      GHC_FOR_BENCHMARKS: "9.10.3"
+      OS_FOR_BENCHMARKS: "ubuntu-24.04"
+      criterion_datadir: ${{ github.workspace }}/html-data
+      js_chart_datadir: ${{ github.workspace }}/html-data
+
+    steps:
+      - name: Download artifacts
+        uses : actions/download-artifact@v5
+        with:
+          pattern: pact-applications.${{ env.GHC_FOR_BENCHMARKS }}.${{ env.OS_FOR_BENCHMARKS }}
+          path: pact_apps
+
+      - name: Download Criterion templates
+        run: |
+          mkdir -p $criterion_datadir/templates
+          cd $criterion_datadir/templates
+          wget https://raw.githubusercontent.com/haskell/criterion/refs/heads/master/templates/criterion.css
+          wget https://raw.githubusercontent.com/haskell/criterion/refs/heads/master/templates/criterion.js
+          wget https://raw.githubusercontent.com/haskell/criterion/refs/heads/master/templates/default.tpl
+          wget https://raw.githubusercontent.com/haskell/criterion/refs/heads/master/templates/json.tpl
+
+          cd ${js_chart_datadir}
+          wget  https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.js
+          wget  https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.css
+
+
+      - name: List directory
+        shell: bash
+        run: ls -lR .
+
+      - name: Run gasmodel
+        run: |
+          mkdir -p results
+          cd pact_apps
+          chmod +x run_gasmodel
+          ./run_gasmodel -o ../results/gasmodel_results.html --json ../results/gasmodel_results.json --csv ../results/gasmodel_results.csv
+
+      - name: Publish Gasmodel
+        uses: actions/upload-artifact@v4
+        with:
+          name: gasmodel
+          path: results

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -1,5 +1,5 @@
 
-name: Build / Release / Benchamrk
+name: Build / Release / Benchmark
 
 # Build on each commit
 # Gasmodel and release must be manually selected.

--- a/gasmodel/Pact/Core/GasModel/BuiltinsGas.hs
+++ b/gasmodel/Pact/Core/GasModel/BuiltinsGas.hs
@@ -104,6 +104,16 @@ benchArithBinOp op pdb =
   where
   vals = take 10 $ enumExpText 10 10
 
+benchArithBinHomoOp :: T.Text -> BuiltinBenches
+benchArithBinHomoOp op pdb =
+  [ C.bgroup "integer"
+    [ runNativeBenchmark pdb title [text|($op $x $x)|] | (title, x) <- vals ]
+  , C.bgroup "float"
+    [ runNativeBenchmark pdb title [text|($op $x.0 $x.0)|] | (title, x) <- vals ]
+  ]
+  where
+  vals = take 10 $ enumExpText 10 10
+
 benchPow :: BuiltinBenches
 benchPow pdb =
   [ C.bgroup "integer"
@@ -119,7 +129,7 @@ benchPow pdb =
     [ runNativeBenchmark pdb title [text|(^ 2 $x.0)|] | (title, x) <- floatVals ]
   ]
   where
-  floatVals = take 10 $ enumExpText 10 10
+  floatVals = take 6 $ enumExpText 10 10
 
 benchArithUnOp :: T.Text -> BuiltinBenches
 benchArithUnOp op pdb =
@@ -161,8 +171,8 @@ benchNegate pdb =
   where
   vals = take 3 $ enumExpText 1_000 1_000_000
 
-benchEqOp :: T.Text -> BuiltinBenches
-benchEqOp op pdb =
+benchEqNonArithOp :: T.Text -> BuiltinBenches
+benchEqNonArithOp op pdb =
   [ C.bgroup "lists-same" listsEq
   , C.bgroup "lists-diff" listsNeq
   , C.bgroup "lists-deep" listsDeep
@@ -199,7 +209,7 @@ benchIntegerBinOp growth op pdb =
 
 benchBitwiseFlip :: BuiltinBenches
 benchBitwiseFlip pdb =
-  [ runNativeBenchmark pdb title [text|(~ $x $x)|]
+  [ runNativeBenchmark pdb title [text|(~ $x)|]
   | (title, x) <- take 3 $ enumExpText 1_000 1_000_000
   ]
 
@@ -253,14 +263,6 @@ benchTakeDrop op pdb =
     , (takeTitle, len) <- take 3 $ enumExpNum 1_000 100
     , fromIntegral len <= T.length s
     , let title = strTitle <> "_" <> takeTitle
-    ]
-  , C.bgroup "object"
-    [ runNativeBenchmarkPrepared [("x", obj), ("keys", PList keys)] pdb title [text|($op keys x)|]
-    | (strTitle, obj@(PObject m)) <- take 3 $ enumExpObject 1_000 100
-    , (takeTitle, len) <- take 3 $ enumExpNum 1_000 100
-    , fromIntegral len <= M.size m
-    , let title = strTitle <> "_" <> takeTitle
-    , let keys = V.fromList $ fmap fieldToValue $ take (fromIntegral len) $ M.keys m
     ]
   ]
 
@@ -482,14 +484,14 @@ benchDistinct pdb =
 benchReadOp :: T.Text -> BuiltinBenches
 benchReadOp readOp pdb =
   [ runNativeBenchmarkPreparedEnvMod (msgBody obj) [("k", key)] pdb title [text|($readOp k)|]
-  | (title, PObject obj) <- take 3 $ enumExpObjectWithStrings 100 1_000 100
+  | (title, PObject obj) <- take 3 $ enumExpObjectWithStrings 100 1_000 10
   , let key = fieldToValue $ last $ M.keys obj
   ]
 
 benchReadString :: BuiltinBenches
 benchReadString pdb =
   [ runNativeBenchmarkPreparedEnvMod (msgBody obj) [("k", key)] pdb title "(read-string k)"
-  | (title, PObject obj) <- take 3 $ enumExpObjectWithStrings 10 1_000 100
+  | (title, PObject obj) <- take 3 $ enumExpObjectWithStrings 10 1_000 10
   , let key = fieldToValue $ last $ M.keys obj
   ]
 
@@ -780,12 +782,12 @@ benchesForBuiltin bn = case bn of
   CoreAbs -> benchArithUnOp "abs"
   CorePow -> benchPow
   CoreNot -> omittedDeliberately
-  CoreEq -> benchEqOp "="
-  CoreNeq -> benchEqOp "!="
-  CoreGT -> benchEqOp ">"
-  CoreGEQ -> benchEqOp ">="
-  CoreLT -> benchEqOp "<"
-  CoreLEQ -> benchEqOp "<="
+  CoreEq -> benchEqNonArithOp "=" <> benchArithBinOp "="
+  CoreNeq -> benchEqNonArithOp "!=" <> benchArithBinOp "!="
+  CoreGT -> benchArithBinHomoOp ">"
+  CoreGEQ -> benchArithBinHomoOp ">="
+  CoreLT -> benchArithBinHomoOp "<"
+  CoreLEQ -> benchArithBinHomoOp "<="
   CoreBitwiseAnd -> benchIntegerBinOp 1_000_000 "&"
   CoreBitwiseOr -> benchIntegerBinOp 1_000_000 "|"
   CoreBitwiseXor -> benchIntegerBinOp 1_000_000 "xor"


### PR DESCRIPTION
This PR fixes the gasmodel benchmark.

The PR adds a Github workflow (manually triggered) to run the benchmark. It takes like 2 hours. But then results (HTML, CSV, and JSON) are published as artifacts.

