### PR TITLE
Fix time overflow

### DIFF
--- a/pact-repl/Pact/Core/IR/Eval/Direct/CoreBuiltin.hs
+++ b/pact-repl/Pact/Core/IR/Eval/Direct/CoreBuiltin.hs
@@ -1467,7 +1467,9 @@ parseTime info b _env = \case
   [VString fmt, VString s] -> do
     chargeGasArgs info $ GStrOp $ StrOpParseTime (T.length fmt) (T.length s)
     case PactTime.parseTime (T.unpack fmt) (T.unpack s) of
-      Just t -> return $ VPactValue (PTime t)
+      Just t -> do
+        t' <- timeChecked info t
+        return $ VPactValue (PTime t')
       Nothing ->
         throwNativeExecutionError info b $ "parse-time parse failure"
   args -> argsError info b args
@@ -1484,7 +1486,9 @@ time :: (IsBuiltin b) => NativeFunction e b i
 time info b _env = \case
   [VString s] -> do
     case PactTime.parseTime "%Y-%m-%dT%H:%M:%SZ" (T.unpack s) of
-      Just t -> return $ VPactValue (PTime t)
+      Just t -> do
+        t' <- timeChecked info t
+        return $ VPactValue (PTime t')
       Nothing ->
         throwNativeExecutionError info b $ "time default format parse failure"
   args -> argsError info b args
@@ -1492,10 +1496,12 @@ time info b _env = \case
 addTime :: (IsBuiltin b) => NativeFunction e b i
 addTime info b _env = \case
   [VPactValue (PTime t), VPactValue (PDecimal seconds)] -> do
-      let newTime = t PactTime..+^ PactTime.fromSeconds seconds
+      seconds' <- deltaChecked info seconds
+      newTime <- timeChecked info $ t PactTime..+^ PactTime.fromSeconds seconds'
       return $ VPactValue (PTime newTime)
   [VPactValue (PTime t), VPactValue (PInteger seconds)] -> do
-      let newTime = t PactTime..+^ PactTime.fromSeconds (fromIntegral seconds)
+      seconds' <- deltaChecked info $ fromIntegral seconds
+      newTime <- timeChecked info $ t PactTime..+^ PactTime.fromSeconds seconds'
       return $ VPactValue (PTime newTime)
   args -> argsError info b args
 

--- a/pact-repl/Pact/Core/IR/Eval/Direct/CoreBuiltin.hs
+++ b/pact-repl/Pact/Core/IR/Eval/Direct/CoreBuiltin.hs
@@ -906,11 +906,13 @@ coreReadMsg info b _env = \case
       PObject envData -> do
         chargeGasArgs info $ GObjOp $ ObjOpLookup s $ M.size envData
         case M.lookup (Field s) envData of
-          Just pv -> return (VPactValue pv)
+          Just pv -> do
+            pv' <- timeCheckedInPactValue info pv
+            return (VPactValue pv')
           _ -> throwReadError info b
       _ -> throwReadError info b
   [] -> do
-    envData <- viewEvalEnv eeMsgBody
+    envData <- timeCheckedInPactValue info =<< viewEvalEnv eeMsgBody
     return (VPactValue envData)
   args -> argsError info b args
 

--- a/pact-tests/constructor-tag-goldens/EvalError.golden
+++ b/pact-tests/constructor-tag-goldens/EvalError.golden
@@ -77,4 +77,5 @@
 {"conName":"EntityNotAllowedInDefPact","conIndex":"4c"}
 {"conName":"Keccak256Error","conIndex":"4d"}
 {"conName":"TypecheckingFailure","conIndex":"4e"}
+{"conName":"TimeOverflowError","conIndex":"4f"}
 

--- a/pact-tests/pact-tests/time-overflow.repl
+++ b/pact-tests/pact-tests/time-overflow.repl
@@ -45,15 +45,6 @@
 ; Do exact same thing but remove the flag
 
 (env-exec-config [])
-(defconst PLUS_1K_YEARS (* 1000.0 (days 365.2425)))
-(defconst MINUS_1K_YEARS (- PLUS_1K_YEARS))
-
-(defconst PLUS_300K_YEARS (* 300000.0 (days 365.2425)))
-(defconst MINUS_300K_YEARS (- PLUS_300K_YEARS))
-
-(defconst TODAY "2026-02-26T00:00:00Z")
-
-;(defconst LONG_TIME_IN_FUTURE (time "200026-02-26T00:00:00Z"))
 
 ; Do sanity checks
 (expect-that "Adding small quantities of time is OK"    (compose (format-time "%F") (= "3026-02-26")) (add-time (time TODAY) PLUS_1K_YEARS))

--- a/pact-tests/pact-tests/time-overflow.repl
+++ b/pact-tests/pact-tests/time-overflow.repl
@@ -13,7 +13,9 @@
 (defconst MINUS_300K_YEARS (- PLUS_300K_YEARS))
 
 (defconst TODAY "2026-02-26T00:00:00Z")
+(defconst TODAY_PRECISE "2026-02-26T00:00:00.123456Z")
 (defconst LONG_TIME_IN_FUTURE "294134-11-26T00:00:00Z")
+(defconst LONG_TIME_IN_FUTURE_PRECISE "294134-11-26T00:00:00.123456Z")
 (defconst LONG_TIME_IN_PAST "-290000-11-07T00:00:00Z")
 
 ; Do sanity checks
@@ -35,6 +37,20 @@
 
 ; Diff time between FUTURE and PAST => Overflow, we obtain a negative number
 (expect "Time diff is negative, should be positive in theory" -13253875309.551616 (diff-time (time LONG_TIME_IN_FUTURE) (time LONG_TIME_IN_PAST)))
+
+; Check that problematic datetime can be read from the env data
+(env-data {"a": {"time":LONG_TIME_IN_FUTURE}})
+(expect-that "Read OK" (compose (format-time "%F") (= "294134-11-26")) (read-msg 'a))
+
+(env-data {"a": {"timep":LONG_TIME_IN_FUTURE_PRECISE}})
+(expect-that "Read OK" (compose (format-time "%F") (= "294134-11-26")) (read-msg 'a))
+
+(env-data {"a": [{"time":LONG_TIME_IN_FUTURE}]})
+(expect-that "Read OK" (compose (format-time "%F") (= "294134-11-26")) (at 0 (read-msg 'a)))
+
+(env-data {"a": {"my-field": {"time":LONG_TIME_IN_FUTURE}}})
+(expect-that "Read OK" (compose (format-time "%F") (= "294134-11-26")) (at 'my-field (read-msg 'a)))
+
 (commit-tx)
 
 
@@ -63,6 +79,33 @@
 (expect-failure "Time overflow" "Time overflow" (add-time (time LONG_TIME_IN_PAST) MINUS_1K_YEARS))
 
 (expect-failure "Time overflow" "Time overflow" (diff-time (time LONG_TIME_IN_FUTURE) (time LONG_TIME_IN_PAST)))
+
+; Check that problematic datetime can NOT  be read from the env data
+(env-data {"a": {"time":LONG_TIME_IN_FUTURE}})
+(expect-failure "Time overflow" "Time overflow" (read-msg 'a))
+
+(env-data {"a": {"timep":LONG_TIME_IN_FUTURE_PRECISE}})
+(expect-failure "Time overflow" "Time overflow" (read-msg 'a))
+
+(env-data {"a": [{"time":LONG_TIME_IN_FUTURE}]})
+(expect-failure "Time overflow" "Time overflow" (at 0 (read-msg 'a)))
+
+(env-data {"a": {"my-field": {"time":LONG_TIME_IN_FUTURE}}})
+(expect-failure "Time overflow" "Time overflow" (at 'my-field (read-msg 'a)))
+
+
+; But valid datetime can still be read
+(env-data {"a": {"time":TODAY}})
+(expect-that "Read OK" (compose (format-time "%F") (= "2026-02-26")) (read-msg 'a))
+
+(env-data {"a": {"timep":TODAY_PRECISE}})
+(expect-that "Read OK" (compose (format-time "%F") (= "2026-02-26")) (read-msg 'a))
+
+(env-data {"a": [{"time":TODAY}]})
+(expect-that "Read OK" (compose (format-time "%F") (= "2026-02-26")) (at 0 (read-msg 'a)))
+
+(env-data {"a": {"my-field": {"time":TODAY}}})
+(expect-that "Read OK" (compose (format-time "%F") (= "2026-02-26")) (at 'my-field (read-msg 'a)))
 
 (commit-tx)
 

--- a/pact-tests/pact-tests/time-overflow.repl
+++ b/pact-tests/pact-tests/time-overflow.repl
@@ -1,0 +1,156 @@
+;; time-overflow.repl: time-overflow unit tests
+
+;----------------------------------------------------------------------------------------------------------------
+;----------------------------------------------------------------------------------------------------------------
+; Part 1 => Test using the old behaviour = with DisableSafeTime => Bug appear
+(begin-tx)
+
+(env-exec-config ["DisableSafeTime"])
+(defconst PLUS_1K_YEARS (* 1000.0 (days 365.2425)))
+(defconst MINUS_1K_YEARS (- PLUS_1K_YEARS))
+
+(defconst PLUS_300K_YEARS (* 300000.0 (days 365.2425)))
+(defconst MINUS_300K_YEARS (- PLUS_300K_YEARS))
+
+(defconst TODAY "2026-02-26T00:00:00Z")
+(defconst LONG_TIME_IN_FUTURE "294134-11-26T00:00:00Z")
+(defconst LONG_TIME_IN_PAST "-290000-11-07T00:00:00Z")
+
+; Do sanity checks
+(expect-that "Adding small quantities of time is OK"    (compose (format-time "%F") (= "3026-02-26")) (add-time (time TODAY) PLUS_1K_YEARS))
+(expect-that "Deducting small quantities of time is OK" (compose (format-time "%F") (= "1026-02-26")) (add-time (time TODAY) MINUS_1K_YEARS))
+
+
+; Add 300K years in the future => And we come in the past => WTF
+(expect-that "Time is fucking wrong" (compose (format-time "%Y") (= "-282528")) (add-time (time TODAY) PLUS_300K_YEARS))
+
+; Go 300K years in the past => And we come in the future => WTF
+(expect-that "Time is fucking wrong" (compose (format-time "%Y") (= "286580")) (add-time (time TODAY) MINUS_300K_YEARS))
+
+; Start from year 294k and add 1k, => Overflow, we are in the past
+(expect-that "Time is fucking wrong" (compose (format-time "%Y") (= "-289420")) (add-time (time LONG_TIME_IN_FUTURE) PLUS_1K_YEARS))
+
+; Start from year -290k and substract 1k, => Overflow, we are in the future
+(expect-that "Time is fucking wrong" (compose (format-time "%Y") (= "293554")) (add-time (time LONG_TIME_IN_PAST) MINUS_1K_YEARS))
+
+; Diff time between FUTURE and PAST => Overflow, we obtain a negative number
+(expect "Time diff is negative, should be positive in theory" -13253875309.551616 (diff-time (time LONG_TIME_IN_FUTURE) (time LONG_TIME_IN_PAST)))
+(commit-tx)
+
+
+;----------------------------------------------------------------------------------------------------------------
+;----------------------------------------------------------------------------------------------------------------
+; Part 2 => Do exactly the sames tests with the new behaviour = without DisableSafeTime => And show it's fixed
+(begin-tx)
+; Do exact same thing but remove the flag
+
+(env-exec-config [])
+(defconst PLUS_1K_YEARS (* 1000.0 (days 365.2425)))
+(defconst MINUS_1K_YEARS (- PLUS_1K_YEARS))
+
+(defconst PLUS_300K_YEARS (* 300000.0 (days 365.2425)))
+(defconst MINUS_300K_YEARS (- PLUS_300K_YEARS))
+
+(defconst TODAY "2026-02-26T00:00:00Z")
+
+;(defconst LONG_TIME_IN_FUTURE (time "200026-02-26T00:00:00Z"))
+
+; Do sanity checks
+(expect-that "Adding small quantities of time is OK"    (compose (format-time "%F") (= "3026-02-26")) (add-time (time TODAY) PLUS_1K_YEARS))
+(expect-that "Deducting small quantities of time is OK" (compose (format-time "%F") (= "1026-02-26")) (add-time (time TODAY) MINUS_1K_YEARS))
+
+; Add 300K years => Pact should now catch it
+(expect-failure "Time overflow" "Time overflow" (add-time (time TODAY) PLUS_300K_YEARS))
+
+; Go 300K years in the past => Pact should now catch it
+(expect-failure "Time overflow" "Time overflow" (add-time (time TODAY) MINUS_300K_YEARS))
+
+; Start from year 294k and add 1k, => Pact should now catch it
+(expect-failure "Time overflow" "Time overflow" (add-time (time LONG_TIME_IN_FUTURE) PLUS_1K_YEARS))
+
+; Start from year -290k and substract 1k, => => Pact should now catch it
+(expect-failure "Time overflow" "Time overflow" (add-time (time LONG_TIME_IN_PAST) MINUS_1K_YEARS))
+
+(expect-failure "Time overflow" "Time overflow" (diff-time (time LONG_TIME_IN_FUTURE) (time LONG_TIME_IN_PAST)))
+
+(commit-tx)
+
+
+; Part 3 => Test Edge cases with new behaviour
+(begin-tx)
+
+(env-exec-config [])
+
+; The MJD Epoch
+(defconst MJD (time "1858-11-17T00:00:00Z"))
+
+; The MJD Epoch PLUS 1s
+(defconst MJD-PLUS (time "1858-11-17T00:00:01Z"))
+
+; The MJD Epoch MINUS 1s
+(defconst MJD-MINUS (time "1858-11-16T23:59:59Z"))
+
+
+; We don't use the dafault parser, as it doesn't provide mucro-seconds support
+(defconst MICROS_PARSER "%Y-%m-%dT%H:%M:%S.%vZ")
+
+(defconst HIGH_SAFE_TIME         "147997-05-22T14:00:27.387901Z") ; |=> Supposed to be OK
+(defconst HIGH_SAFE_TIME_ROUNDED "147997-05-22T14:00:27Z")        ; |
+
+(defconst HIGH_UNSAFE_TIME         "147997-05-22T14:00:27.387902Z") ; |=> Supposed to trigger a transaction failure
+(defconst HIGH_UNSAFE_TIME_ROUNDED "147997-05-22T14:00:28Z")        ; |
+
+(defconst LOW_SAFE_TIME         "-144280-05-13T09:59:32.612098Z") ; |=> Supposed to be OK
+(defconst LOW_SAFE_TIME_ROUNDED "-144280-05-13T09:59:33Z")        ; |
+
+
+(defconst LOW_UNSAFE_TIME         "-144280-05-13T09:59:32.612097Z") ; |=> Supposed to trigger a transaction failure
+(defconst LOW_UNSAFE_TIME_ROUNDED "-144280-05-13T09:59:32Z")        ; |
+
+; Check that we are not allowed to use unsafe times, and that safe times are correct
+(expect-that "Good date" (compose (format-time "%F") (= "147997-05-22")) (time HIGH_SAFE_TIME_ROUNDED))
+(expect-that "Good date" (compose (format-time "%F") (= "147997-05-22")) (parse-time MICROS_PARSER HIGH_SAFE_TIME))
+
+(expect-that "Good date" (compose (format-time "%F") (= "-144280-05-13")) (time LOW_SAFE_TIME_ROUNDED))
+(expect-that "Good date" (compose (format-time "%F") (= "-144280-05-13")) (parse-time MICROS_PARSER LOW_SAFE_TIME))
+
+(expect-failure "Bad date" "Time overflow" (time HIGH_UNSAFE_TIME_ROUNDED))
+(expect-failure "Bad date" "Time overflow" (parse-time MICROS_PARSER HIGH_UNSAFE_TIME))
+(expect-failure "Bad date" "Time overflow" (time LOW_UNSAFE_TIME_ROUNDED))
+(expect-failure "Bad date" "Time overflow" (parse-time MICROS_PARSER LOW_UNSAFE_TIME))
+
+
+; Now check that a difference between the two extrem safe dates is correct
+;   => In the range of 292277 positive years = 9217247472000 psotive seconds
+(expect "Future - Past = Positive" 9223372036854.0      (diff-time (time HIGH_SAFE_TIME_ROUNDED)  (time LOW_SAFE_TIME_ROUNDED)))
+(expect "Future - Past = Positive" 9223372036854.775803 (diff-time (parse-time MICROS_PARSER HIGH_SAFE_TIME) (parse-time MICROS_PARSER LOW_SAFE_TIME)))
+
+; Just for being sure we are safe, we do the same thing but in the opposite : Past - Future should be negative
+(expect "Past - Future = Negative" -9223372036854.0 (diff-time (time LOW_SAFE_TIME_ROUNDED)  (time HIGH_SAFE_TIME_ROUNDED)))
+(expect "Past - Future = Negative" -9223372036854.775803 (diff-time (parse-time MICROS_PARSER LOW_SAFE_TIME) (parse-time MICROS_PARSER HIGH_SAFE_TIME)))
+
+
+; Now we test the delta from the MJD Epoch
+
+(defconst HIGH_SAFE_DELTA   4611686018427.387901) ; => Supposed to be OK
+(defconst HIGH_UNSAFE_DELTA 4611686018427.387902) ; => Supposed to trigger a transaction failure
+
+(defconst LOW_SAFE_DELTA   -4611686018427.387902) ; => Supposed to be OK
+(defconst LOW_UNSAFE_DELTA -4611686018427.387903) ; => Supposed to trigger a transaction failure
+
+
+(expect-that "MJD + Safe Delta => In the future"         (compose (format-time "%Y") (= "147997")) (add-time MJD HIGH_SAFE_DELTA))
+(expect-that "MJD + Negative Safe Delta => In the past"  (compose (format-time "%Y") (= "-144280")) (add-time MJD LOW_SAFE_DELTA))
+
+; Using Unsafe deltas => Trigger a failure
+(expect-failure "Bad date" "Time overflow"  (add-time MJD HIGH_UNSAFE_DELTA))
+(expect-failure "Bad date" "Time overflow"  (add-time MJD LOW_UNSAFE_DELTA))
+
+; Final Test using a offseted MJD but with a safe delta should push the date in the overflow zone
+(expect-failure "Bad date" "Time overflow"  (add-time MJD-PLUS HIGH_SAFE_DELTA))
+(expect-failure "Bad date" "Time overflow"  (add-time MJD-MINUS LOW_SAFE_DELTA))
+
+
+; OK -> That's it, I think, at this point, we have a complete coverage now, and there is no possibility of overflow anymore.
+
+(commit-tx)

--- a/pact/Pact/Core/Environment/Types.hs
+++ b/pact/Pact/Core/Environment/Types.hs
@@ -187,6 +187,8 @@ data ExecutionFlag
   | FlagDisablePact54
   -- | Flag to enable modref read-only mode
   | FlagDisableReentrancyCheck
+  -- | Flag to disable owverflow check
+  | FlagDisableSafeTime
   deriving (Eq,Ord,Show,Enum,Bounded, Generic)
 
 instance NFData ExecutionFlag

--- a/pact/Pact/Core/Environment/Types.hs
+++ b/pact/Pact/Core/Environment/Types.hs
@@ -187,7 +187,7 @@ data ExecutionFlag
   | FlagDisablePact54
   -- | Flag to enable modref read-only mode
   | FlagDisableReentrancyCheck
-  -- | Flag to disable owverflow check
+  -- | Flag to disable overflow check
   | FlagDisableSafeTime
   deriving (Eq,Ord,Show,Enum,Bounded, Generic)
 

--- a/pact/Pact/Core/Errors.hs
+++ b/pact/Pact/Core/Errors.hs
@@ -568,8 +568,6 @@ data EvalError
   -- ^ Array index out of bounds <length> <index>
   | ArithmeticException Text
   -- ^ Arithmetic error <cause>
-  | TimeOverflowError
-  -- ^ A possible overflow is detected in time
   | EnumerationError Text
   -- ^ Enumeration error (e.g incorrect bounds with step
   | DecodeError Text
@@ -737,6 +735,8 @@ data EvalError
   -- ^ Keccak256 failure
   | TypecheckingFailure ModuleName Text
   -- ^ Typechecking failure
+  | TimeOverflowError
+  -- ^ A possible overflow is detected in time
   deriving (Eq, Show, Generic)
 
 data ErrorClosureType

--- a/pact/Pact/Core/Errors.hs
+++ b/pact/Pact/Core/Errors.hs
@@ -89,6 +89,7 @@ module Pact.Core.Errors
  , _InvalidBlessedHash
  , _ArrayOutOfBoundsException
  , _ArithmeticException
+ , _TimeOverflowError
  , _EnumerationError
  , _DecodeError
  , _GasExceeded
@@ -567,6 +568,8 @@ data EvalError
   -- ^ Array index out of bounds <length> <index>
   | ArithmeticException Text
   -- ^ Arithmetic error <cause>
+  | TimeOverflowError
+  -- ^ A possible overflow is detected in time
   | EnumerationError Text
   -- ^ Enumeration error (e.g incorrect bounds with step
   | DecodeError Text
@@ -763,6 +766,8 @@ instance Pretty EvalError where
       , Pretty.parens (pretty ix)]
     ArithmeticException txt ->
       Pretty.hsep ["Arithmetic exception:", pretty txt]
+    TimeOverflowError ->
+      "Time overflow : too far in the past or in the future"
     EnumerationError txt ->
       Pretty.hsep ["Enumeration error:", pretty txt]
     DecodeError txt ->
@@ -1423,6 +1428,8 @@ evalErrorToBoundedText = mkBoundedText . \case
     , tInt ix]
   ArithmeticException txt ->
     thsep ["Arithmetic exception:", txt]
+  TimeOverflowError ->
+    "Time overflow"
   EnumerationError txt ->
     thsep ["Enumeration error:", txt]
   DecodeError txt ->

--- a/pact/Pact/Core/IR/Eval/CEK/CoreBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/CoreBuiltin.hs
@@ -1476,7 +1476,9 @@ parseTime info b cont handler _env = \case
   [VString fmt, VString s] -> do
     chargeGasArgs info $ GStrOp $ StrOpParseTime (T.length fmt) (T.length s)
     case PactTime.parseTime (T.unpack fmt) (T.unpack s) of
-      Just t -> returnCEKValue cont handler $ VPactValue (PTime t)
+      Just t -> do
+        t' <- timeChecked info t
+        returnCEKValue cont handler $ VPactValue (PTime t')
       Nothing ->
         throwNativeExecutionError info b $ "parse-time parse failure"
   args -> argsError info b args
@@ -1493,7 +1495,9 @@ time :: (IsBuiltin b) => NativeFunction e b i
 time info b cont handler _env = \case
   [VString s] -> do
     case PactTime.parseTime "%Y-%m-%dT%H:%M:%SZ" (T.unpack s) of
-      Just t -> returnCEKValue cont handler $ VPactValue (PTime t)
+      Just t -> do
+        t' <- timeChecked info t
+        returnCEKValue cont handler $ VPactValue (PTime t')
       Nothing ->
         throwNativeExecutionError info b $ "time default format parse failure"
   args -> argsError info b args
@@ -1501,10 +1505,12 @@ time info b cont handler _env = \case
 addTime :: (IsBuiltin b) => NativeFunction e b i
 addTime info b cont handler _env = \case
   [VPactValue (PTime t), VPactValue (PDecimal seconds)] -> do
-      let newTime = t PactTime..+^ PactTime.fromSeconds seconds
+      seconds' <- deltaChecked info seconds
+      newTime <- timeChecked info $ t PactTime..+^ PactTime.fromSeconds seconds'
       returnCEKValue cont handler $ VPactValue (PTime newTime)
   [VPactValue (PTime t), VPactValue (PInteger seconds)] -> do
-      let newTime = t PactTime..+^ PactTime.fromSeconds (fromIntegral seconds)
+      seconds' <- deltaChecked info $ fromIntegral seconds
+      newTime <- timeChecked info $ t PactTime..+^ PactTime.fromSeconds seconds'
       returnCEKValue cont handler $ VPactValue (PTime newTime)
   args -> argsError info b args
 

--- a/pact/Pact/Core/IR/Eval/CEK/CoreBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/CoreBuiltin.hs
@@ -913,11 +913,13 @@ coreReadMsg info b cont handler _env = \case
       PObject envData -> do
         chargeGasArgs info $ GObjOp $ ObjOpLookup s $ M.size envData
         case M.lookup (Field s) envData of
-          Just pv -> returnCEKValue cont handler (VPactValue pv)
+          Just pv -> do
+            pv' <- timeCheckedInPactValue info pv
+            returnCEKValue cont handler (VPactValue pv')
           _ -> throwReadError info cont handler b
       _ -> throwReadError info cont handler b
   [] -> do
-    envData <- viewEvalEnv eeMsgBody
+    envData <- timeCheckedInPactValue info =<< viewEvalEnv eeMsgBody
     returnCEKValue cont handler (VPactValue envData)
   args -> argsError info b args
 

--- a/pact/Pact/Core/IR/Eval/Runtime/Utils.hs
+++ b/pact/Pact/Core/IR/Eval/Runtime/Utils.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE BlockArguments #-}
 
 module Pact.Core.IR.Eval.Runtime.Utils
  ( checkSigCaps
@@ -63,6 +64,8 @@ module Pact.Core.IR.Eval.Runtime.Utils
  , lookupFqNameOrFail
  , isCapInStack
  , isCapInStack'
+ , timeChecked
+ , deltaChecked
  ) where
 
 import Control.Lens hiding (from, to)
@@ -75,9 +78,13 @@ import Data.Maybe(maybeToList)
 import Data.Text(Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import qualified Pact.Time.Internal as PT (divNominalDiffTime)
+import qualified Pact.Time as PT
 import qualified Data.Map.Strict as M
 import qualified Data.Vector as V
 import qualified Data.Set as S
+import Data.Decimal (Decimal)
+
 
 import Pact.Core.Names
 import Pact.Core.PactValue
@@ -689,3 +696,24 @@ isCapInStack'
   -> EvalM e b i Bool
 isCapInStack' (CapToken fqn args) =
   isCapInStack (CapToken (fqnToQualName fqn) args)
+
+minSafeDiffTime:: PT.NominalDiffTime
+minSafeDiffTime = succ $ PT.divNominalDiffTime minBound (2::Int)
+
+maxSafeDiffTime:: PT.NominalDiffTime
+maxSafeDiffTime = pred $ PT.divNominalDiffTime maxBound (2::Int)
+
+deltaChecked :: i -> Decimal -> EvalM e b i Decimal
+deltaChecked info delta = do
+  unlessExecutionFlagSet FlagDisableSafeTime if delta <= PT.toSeconds minSafeDiffTime || delta >= PT.toSeconds maxSafeDiffTime
+                                             then throwExecutionError info TimeOverflowError
+                                             else return ()
+  return delta
+
+
+timeChecked :: i -> PT.UTCTime -> EvalM e b i PT.UTCTime
+timeChecked info t = do
+  unlessExecutionFlagSet FlagDisableSafeTime if t <= (PT.mjdEpoch PT..+^ minSafeDiffTime) || t >= (PT.mjdEpoch PT..+^ maxSafeDiffTime)
+                                             then throwExecutionError info TimeOverflowError
+                                             else return ()
+  return t

--- a/pact/Pact/Core/IR/Eval/Runtime/Utils.hs
+++ b/pact/Pact/Core/IR/Eval/Runtime/Utils.hs
@@ -66,6 +66,7 @@ module Pact.Core.IR.Eval.Runtime.Utils
  , isCapInStack'
  , timeChecked
  , deltaChecked
+ , timeCheckedInPactValue
  ) where
 
 import Control.Lens hiding (from, to)
@@ -717,3 +718,12 @@ timeChecked info t = do
                                              then throwExecutionError info TimeOverflowError
                                              else return ()
   return t
+
+-- Recursively check invalid datetimes in a complex nested PactValue
+timeCheckedInPactValue :: i -> PactValue -> EvalM e b i PactValue
+timeCheckedInPactValue info pv = go pv >> return pv
+  where
+    go (PTime t) = void $ timeChecked info t
+    go (PList pl) = mapM_ go pl
+    go (PObject po) = mapM_ go po
+    go _ = return ()


### PR DESCRIPTION
This PR is trying to fix:
https://github.com/kda-community/pact-5/issues/9
https://github.com/kadena-io/pact-5/issues/84


This is not only a simple whim, but this issue allows writing contracts that “looks correct”, but that can be hardly and badly exploited, with loss of funds (I can give such example). That's why I consider it as SERIOUS. There are some MRE in the UT repl script that show at which point we are fucked.

The only reason of this bug is that a datetime in Pact is encoded with a fixed signed int64, in the pact-time lib.

I explored 2 options to fix it:

**Option 1:** Looks clean, but...
Simply rewrite the pact-time lib and use under the hood a Haskell **Integer**.
But with the following drawbacks:
- Need to maintain 2 different pact-time lib in parallel.. with a mess similar to the Pact4/Pact5 integration in Chainweb.
- Need to maintain a compatibility, and some transfer procedures between the two different versions of the pact-time lib.
- Because of unbounded types, we need to add a new gassing layer for time (similar of what we do for integers math) 
- This is mostly overkill. Referencing dates from the paleolithic era, to the Post-Nuclear-Apocalyptic /or/ Interstellar era (choose what you prefer :smiley: depends on your mood) is not a use-case.


**Option 2**: The one implemented here.
Avoid overflows by bounding dates and delta (used in add-time), to half of the range of a signed int64. This solution is simple and efficient.
Basically:
1 - Every functions that output datetimes (namely ``time``, ``parse-time``, ``add-time`` and ``read-msg``) must enforce that every outputed date is in the half-int64-range.
2 - Function ``(add-time time offset)`` must enforce that the offset is in the half-int64-range. Since the input time is supposed to be in the half-range too (because of 1), any risk of overflow is eliminated.

Purposely, I don't want to do any enforcement of date already present in tables, to not break existing contracts. 