### PR TITLE
Update crypton, and replace memory by ram

### DIFF
--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -79,8 +79,8 @@ common pact-common
     , vector
     , vector-algorithms
     , megaparsec
-    , crypton
-    , memory
+    , crypton >=1.1.2
+    , ram >=0.2.2 
     , safe-exceptions
     , ralist >= 0.4.0.0
     , haskeline


### PR DESCRIPTION
It looks like there is a small drama around the "memory" library. As such, Crypton upgraded to a fork of "memory" called ram.

This PR upgrade Crypton, and uses now "ram" as a dependency.
