### PR TITLE
GHC 9.14

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -44,8 +44,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.8.2", "9.10.3"]
-        cabal: ["3.12"]
+        ghc: ["9.14.1"]
+        cabal: ["3.16"]
         os: ["ubuntu-22.04", "ubuntu-24.04", "macos-14", "macos-15"]
         cabalcache: ["true"]
 

--- a/cabal.project
+++ b/cabal.project
@@ -47,11 +47,24 @@ source-repository-package
   tag: 8df1cff7f279750490fea8ff580294f3e5a3fcaf
   --sha256: sha256-HyWTEtw/dKQduXl5avRckS0oNc9Z5yxeUxvX09wDkDY=
 
-allow-newer: servant-server:*
-allow-newer: servant-client-core:*
-allow-newer: servant-client:*
-allow-newer: servant:*
+
+allow-newer: http-media:containers
 allow-newer: tasty-wai:*
-allow-newer: *:hashable
+
+
+-- To be removed when Servant release an official enabled 9.14 version
+allow-newer: servant-server:*
+allow-newer: servant:*
+allow-newer: servant-client:*
+allow-newer: servant-client-core:*
+
+-- To be removed when CBORG release an official enabled 9.14 version
+allow-newer: serialise:base,
+allow-newer: serialise:containers
+allow-newer: cborg:base
+allow-newer: cborg:containers
+
+-- To be removed when Ordered-containers release an official enabled 9.14 version
+allow-newer: ordered-containers:containers
 
 tests: True

--- a/pact-repl/Pact/Core/IR/Eval/Direct/Types.hs
+++ b/pact-repl/Pact/Core/IR/Eval/Direct/Types.hs
@@ -181,7 +181,7 @@ data CanApply (e :: RuntimeMode) (b :: K.Type) (i :: K.Type)
   deriving (Show, Generic)
 
 
-instance (Show i, Show b) => Show (NativeFn e b i) where
+instance (Show b) => Show (NativeFn e b i) where
   show (NativeFn b _ _ arity _) = unwords
     ["(NativeFn"
     , show b
@@ -190,7 +190,7 @@ instance (Show i, Show b) => Show (NativeFn e b i) where
     , ")"
     ]
 
-instance (Show i, Show b) => Show (PartialNativeFn e b i) where
+instance (Show b) => Show (PartialNativeFn e b i) where
   show (PartialNativeFn b _ _ arity _ _) = unwords
     ["(NativeFn"
     , show b
@@ -230,7 +230,7 @@ data DirectEnv e b i
 instance (NFData b, NFData i) => NFData (DirectEnv e b i)
 
 
-instance (Show i, Show b) => Show (DirectEnv e b i) where
+instance Show (DirectEnv e b i) where
   show (DirectEnv e _ _ _ _ _) = show e
 
 type NativeFunction (e :: RuntimeMode) (b :: K.Type) (i :: K.Type)

--- a/pact-repl/Pact/Core/Typed/Term.hs
+++ b/pact-repl/Pact/Core/Typed/Term.hs
@@ -326,16 +326,16 @@ instance Pretty tyname => Pretty (TypeApp tyname) where
       "@ref" <> Pretty.braces (pretty r)
 
 
-instance (Pretty name, Pretty ty, Pretty b) => Pretty (Defun name ty b i) where
+instance (Pretty ty) => Pretty (Defun name ty b i) where
   pretty (Defun name _args ty _term _) =
     parens $ "defun" <+> pretty name <> ":" <> pretty ty
 
-instance (Pretty name, Pretty ty, Pretty b) => Pretty (DefPact name ty b i) where
+instance Pretty (DefPact name ty b i) where
   pretty (DefPact name _args tys _steps _info) =
     let dpTypes = vsep [ "step" <+> pretty stepIx <+> "type:" <+> pretty ty | (stepIx, ty) <- IM.toList tys]
     in "defpact" <+> pretty name <+> line <+> dpTypes
 
-instance (Pretty name, Pretty ty, Pretty b) => Pretty (DefCap name ty b i) where
+instance (Pretty ty) => Pretty (DefCap name ty b i) where
   pretty (DefCap name _args ty _ _ _) =
       parens $ "defcap" <+> pretty name <> ":" <> pretty ty
 
@@ -358,7 +358,7 @@ instance Pretty (DefConst i) where
   pretty (DefConst n ty v _) =
     parens $ "defconst" <+> pretty n <> ":" <> pretty ty <+> pretty v
 
-instance (Pretty name, Pretty ty, Pretty b) => Pretty (Def name ty b i) where
+instance (Pretty ty) => Pretty (Def name ty b i) where
   pretty = \case
     Dfun d -> pretty d
     DConst d -> pretty d

--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -1,4 +1,4 @@
-cabal-version:       3.8
+cabal-version:       3.16
 name:                pact-tng
 version:             5.4
 -- ^ 4 digit is prerelease, 3- or 2-digit for prod release
@@ -55,7 +55,7 @@ common pact-common
   build-depends:
     , Decimal
     , attoparsec
-    , base
+    , base >= 4.22
     , base16-bytestring
     , base64-bytestring
     , bytestring
@@ -80,7 +80,7 @@ common pact-common
     , vector-algorithms
     , megaparsec
     , crypton >=1.1.2
-    , ram >=0.2.2 
+    , ram >=0.2.2
     , safe-exceptions
     , ralist >= 0.4.0.0
     , haskeline
@@ -166,8 +166,8 @@ library pact-request-api
     , pact-tng:pact-crypto
     , yaml
     , lrucaching
-    , servant-server
-    , servant
+    , servant-server >= 0.20.3
+    , servant >= 0.20.3
     , warp
     , wai-cors
     , wai-logger
@@ -568,9 +568,9 @@ test-suite core-tests
     , safe-exceptions
     , http-conduit
     , direct-sqlite
-    , servant
-    , servant-server
-    , servant-client
+    , servant >= 0.20.3
+    , servant-server >= 0.20.3
+    , servant-client >= 0.20.3
     , lrucaching
     , http-client
     , warp

--- a/pact/Pact/Core/IR/Eval/CEK/Types.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/Types.hs
@@ -149,7 +149,7 @@ data CEKEnv (e :: RuntimeMode) (b :: K.Type) (i :: K.Type)
 
 instance (NFData b, NFData i) => NFData (CEKEnv e b i)
 
-instance (Show i, Show b) => Show (CEKEnv e b i) where
+instance Show (CEKEnv e b i) where
   show (CEKEnv e _ _ _ _ _) = show e
 
 -- | List of builtins
@@ -555,7 +555,7 @@ instance (NFData b, NFData i) => NFData (CEKErrorHandler e b i)
 --   CEKEvalResult e CEKBigStep b i = EvalResult e CEKBigStep b i
 --   CEKEvalResult e CEKSmallStep b i = CEKReturn e b i
 
-instance (Show i, Show b) => Show (NativeFn e b i) where
+instance (Show b) => Show (NativeFn e b i) where
   show (NativeFn b _ _ arity _) = unwords
     ["(NativeFn"
     , show b
@@ -564,7 +564,7 @@ instance (Show i, Show b) => Show (NativeFn e b i) where
     , ")"
     ]
 
-instance (Show i, Show b) => Show (PartialNativeFn e b i) where
+instance (Show b) => Show (PartialNativeFn e b i) where
   show (PartialNativeFn b _ _ arity _ _) = unwords
     ["(NativeFn"
     , show b
@@ -573,10 +573,10 @@ instance (Show i, Show b) => Show (PartialNativeFn e b i) where
     , ")"
     ]
 
-instance (Pretty b, Show i, Show b) => Pretty (NativeFn e b i) where
+instance (Show b) => Pretty (NativeFn e b i) where
   pretty = pretty . show
 
-instance (Show i, Show b, Pretty b) => Pretty (CEKValue e b i) where
+instance Pretty (CEKValue e b i) where
   pretty = \case
     VPactValue pv -> pretty pv
     VClosure{} ->

--- a/pact/Pact/Core/IR/Term.hs
+++ b/pact/Pact/Core/IR/Term.hs
@@ -289,7 +289,7 @@ instance NFData (TableSchema name) where
   rnf (DesugaredTable pn) = rnf pn
   rnf (ResolvedTable sc) = rnf sc
 
-instance Eq name => Eq (TableSchema name) where
+instance Eq (TableSchema name) where
   (DesugaredTable a) == (DesugaredTable b) = a == b
   (ResolvedTable a) == (ResolvedTable b) = a == b
 

--- a/pact/Pact/Core/NativeShadowing.hs
+++ b/pact/Pact/Core/NativeShadowing.hs
@@ -78,7 +78,7 @@ data Shadows i
   = Shadows ShadowCtx Text i
   deriving (Eq, Show)
 
-instance Pretty i => Pretty (Shadows i) where
+instance Pretty (Shadows i) where
   pretty (Shadows ctx shadowedVar _) =
     "Variable" <+> pretty shadowedVar <+> "shadows native of the same name" <+> pretty ctx
 


### PR DESCRIPTION
Since GHC 9.14 will be LTS, I think it's important to make sure that the whole Kadena eco-system compiles with GHC 9.14:

This PR:
 - Fix some new warning emitted by GHC 9.14. @jmcardon added some unnecessary constraints on Show / Pretty implementations of of some types.
 - Fix some dependencies. Some are not already released for GHC. Relax constraints on base Haskell lib. 