### PR TITLE
Fix #ifdef

### DIFF
--- a/pact-repl/Pact/Core/IR/Eval/Direct/CoreBuiltin.hs
+++ b/pact-repl/Pact/Core/IR/Eval/Direct/CoreBuiltin.hs
@@ -40,7 +40,7 @@ import qualified GHC.Exts as Exts
 import qualified GHC.Integer.Logarithms as IntLog
 import qualified Data.List as L
 
-#ifdef WITH_TRACING
+#ifdef WITH_NATIVE_TRACING
 import System.Clock
 #endif
 

--- a/pact-repl/Pact/Core/IR/Eval/Direct/Evaluator.hs
+++ b/pact-repl/Pact/Core/IR/Eval/Direct/Evaluator.hs
@@ -58,7 +58,7 @@ import qualified Data.Set as S
 import qualified Data.Map.Strict as M
 import qualified Data.List.NonEmpty as NE
 
-#ifdef WITH_TRACING
+#ifdef WITH_FUNCALL_TRACING
 import System.Clock
 #endif
 

--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -317,9 +317,6 @@ library pact-repl
   if (flag(with-native-tracing))
     cpp-options: -DWITH_NATIVE_TRACING
 
-  if (flag(with-native-tracing) || flag(with-funcall-tracing))
-    cpp-options: -DWITH_TRACING
-
   exposed-modules:
     Pact.Core.Repl
     Pact.Core.Repl.Utils


### PR DESCRIPTION
When only one of those flag: with-native-tracing or with-funcall-tracing is enabled,

it causes an unused import of System.Clock, throwing a Warning, and doesn't compile.