### PR TITLE
Use Crypton to compute Keccak256 hashes

### DIFF
--- a/crypto/Pact/Core/Crypto/Hash/Keccak256.hs
+++ b/crypto/Pact/Core/Crypto/Hash/Keccak256.hs
@@ -1,58 +1,35 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ImportQualifiedPost #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- | Implementation of the `keccak256` pact native.
 module Pact.Core.Crypto.Hash.Keccak256 (Keccak256Error(..), keccak256) where
 
+import Data.ByteArray as BA
+import Crypto.Hash
 import Control.Exception (Exception(..), SomeException(..))
-import Control.Monad (forM_)
-import Control.Exception.Safe (throwM, try)
 import Control.DeepSeq
-import Data.ByteString(ByteString)
-import Data.ByteString.Short qualified as BSS
-import Data.Coerce
-import Data.Hash.Class.Mutable (initialize, finalize, updateByteString)
-import Data.Hash.Internal.OpenSSL (OpenSslException(..))
-import Data.Hash.Keccak (Keccak256(..))
+import Data.ByteString as BS
 import Data.Text (Text)
 import Data.Text.Encoding qualified as Text
-import Data.Vector (Vector)
+import qualified Data.Vector as V
 import Pact.Core.Crypto.Base64 (encodeBase64UrlUnpadded, decodeBase64UrlUnpadded)
 import GHC.Generics(Generic)
-import System.IO.Unsafe (unsafePerformIO)
 
 data Keccak256Error
-  = Keccak256OpenSslException String
-  | Keccak256Base64Exception String
-  | Keccak256OtherException String
+  = Keccak256Base64Exception String
   deriving stock (Show, Eq, Generic)
   deriving anyclass (Exception)
 
 instance NFData Keccak256Error
 
-keccak256 :: Vector ByteString -> Either Keccak256Error Text
-keccak256 bytesArray = unsafePerformIO $ do
-  e <- try @_ @SomeException $ do
-    ctx <- initialize @Keccak256
-    forM_ bytesArray $ \bytes -> do
-      case decodeBase64UrlUnpadded bytes of
-        Left b64Err -> do
-          throwM (Keccak256Base64Exception b64Err)
-        Right bytes -> do
-          updateByteString @Keccak256 ctx bytes
-    Keccak256 hash <- finalize ctx
-    pure (BSS.fromShort $ coerce hash)
-  case e of
-    Left err
-      | Just (OpenSslException msg) <- fromException err -> pure (Left (Keccak256OpenSslException msg))
-      | Just (exc :: Keccak256Error) <- fromException err -> pure (Left exc)
-      | otherwise -> pure (Left (Keccak256OtherException (displayException err)))
-    Right hash -> pure (Right (Text.decodeUtf8 (encodeBase64UrlUnpadded hash)))
-{-# noinline keccak256 #-}
+keccak256 :: V.Vector BS.ByteString -> Either Keccak256Error Text
+keccak256 bytesArray =
+  case BS.concat <$> (mapM decodeBase64UrlUnpadded $ V.toList bytesArray) of
+    Left b64Err -> Left $ Keccak256Base64Exception b64Err
+    Right bs -> Right $ (Text.decodeUtf8 .  encodeBase64UrlUnpadded . BA.convert . doHash) bs
+
+  where
+    doHash :: BS.ByteString -> Digest Keccak_256
+    doHash = hash

--- a/gasmodel/Pact/Core/GasModel/BuiltinsGas.hs
+++ b/gasmodel/Pact/Core/GasModel/BuiltinsGas.hs
@@ -772,6 +772,14 @@ benchPoseidon pdb =
   , let args = T.unwords $ T.pack . show <$> [1..cnt]
   ]
 
+benchKeccak256 :: BuiltinBenches
+benchKeccak256 pdb =
+  [ runNativeBenchmarkPrepared [("l", lst)] pdb ( lstLenTitle <> " / 4*" <> elemLenTitle  ) "(hash-keccak256 l)"
+  | (elemLenTitle, str) <- take 4 $ enumExpString "YWEK" 25 10
+  , (lstLenTitle, lstLen) <- take 4 $ enumExpNum 1 10
+  , let lst = PList $ V.fromList $ replicate (fromIntegral lstLen) str
+  ]
+
 benchesForBuiltin :: CoreBuiltin -> BuiltinBenches
 benchesForBuiltin bn = case bn of
   CoreAdd -> benchArithBinOp "+" <> benchAddNonArithOverloads
@@ -925,8 +933,7 @@ benchesForBuiltin bn = case bn of
   -- Note: Hash-poseidon is an alias to the poseidon-hash-hackachain
   -- function, so we don't need benches for it
   CoreHashPoseidon -> omittedDeliberately
-  -- TODO: port keccak benchmarks
-  CoreHashKeccak256 -> omittedDeliberately
+  CoreHashKeccak256 -> benchKeccak256
   where
   omittedDeliberately = const []
   alreadyCovered = const []

--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -80,7 +80,7 @@ common pact-common
     , vector-algorithms
     , megaparsec
     , crypton >=1.1.2
-    , ram >=0.2.2 
+    , ram >=0.2.2
     , safe-exceptions
     , ralist >= 0.4.0.0
     , haskeline
@@ -104,7 +104,6 @@ common pact-common
     -- hyperlane deps
     , binary
     , wide-word
-    , ethereum
     , template-haskell
     , pact-tng:unsafe
 
@@ -141,7 +140,8 @@ library pact-crypto
     , text
     , base64-bytestring
     , bytestring
-    , hashes >= 0.3
+    , ram >=0.2.2
+    , crypton
     , safe-exceptions
     , deepseq
 
@@ -580,7 +580,6 @@ test-suite core-tests
     , wai-logger
     , fast-logger
     , property-matchers
-    , hashes >= 0.3
 
   other-modules:
     , Pact.Core.Test.CommandTests

--- a/pact/Pact/Core/Errors.hs
+++ b/pact/Pact/Core/Errors.hs
@@ -951,12 +951,8 @@ instance Pretty EvalError where
     EntityNotAllowedInDefPact qn ->
       "Pact 5 does not support entity expressions in defpact" <+> pretty qn <> ". Please ensure your defpact steps have the correct number of expressions"
     Keccak256Error err -> case err of
-      Keccak256OpenSslException msg ->
-        "OpenSSL error when keccak256 hashing:" <> pretty (T.pack msg)
       Keccak256Base64Exception msg ->
         "Base64URL decode failed:" <+> pretty (T.pack msg)
-      Keccak256OtherException msg ->
-        "Exception when keccak256 hashing:" <+> pretty (T.pack msg)
     TypecheckingFailure mn t ->
       "static typechecking failed for" <+> pretty mn <> hardline <> pretty t
 
@@ -1658,12 +1654,8 @@ evalErrorToBoundedText = mkBoundedText . \case
     thsep ["Keccak256 Hashing failure:", failure]
     where
     failure = case err of
-      Keccak256OpenSslException _msg ->
-        "OpenSSL error"
       Keccak256Base64Exception _msg ->
         "Base64URL decode failed"
-      Keccak256OtherException _ ->
-        "Unknown exception thrown during computation of keccak256"
   TypecheckingFailure mn t ->
     thsep ["static typechecking failed for"
           , renderModuleName mn

--- a/pact/Pact/Crypto/Hyperlane.hs
+++ b/pact/Pact/Crypto/Hyperlane.hs
@@ -24,6 +24,8 @@ module Pact.Crypto.Hyperlane
   , eof
   ) where
 
+import Data.ByteArray as BA
+import qualified Crypto.Hash as Crypton
 import Control.Lens ((^?), at, _Just, Prism')
 import Control.Monad (unless)
 import Control.Monad.Except (throwError)
@@ -35,7 +37,6 @@ import Data.ByteString qualified as BS
 import Data.ByteString.Builder (Builder)
 import Data.ByteString.Builder qualified as BB
 import Data.ByteString.Lazy qualified as BL
-import Data.ByteString.Short qualified as BSS
 import Data.Decimal (Decimal)
 import Data.Map (Map)
 import Data.Ratio ((%))
@@ -45,9 +46,8 @@ import Data.Text.Encoding qualified as Text
 import Data.Text.Read qualified as Text
 import Data.WideWord.Word256 (Word256(..))
 import Data.Word (Word8, Word16, Word32)
-import Ethereum.Misc (keccak256, _getKeccak256Hash, _getBytesN)
 import Pact.JSON.Decode qualified as J
-import Pact.Core.StableEncoding 
+import Pact.Core.StableEncoding
 
 import Pact.Core.Errors
 import Pact.Core.PactValue
@@ -131,7 +131,10 @@ getHyperlaneMessageId =
   . packHyperlaneMessage
 
 keccak256Hash :: ByteString -> ByteString
-keccak256Hash = BSS.fromShort . _getBytesN . _getKeccak256Hash . keccak256
+keccak256Hash = BA.convert . doHash
+  where
+    doHash :: BS.ByteString -> Crypton.Digest Crypton.Keccak_256
+    doHash = Crypton.hash
 
 decodeBase64 :: Field -> Text -> Either HyperlaneError ByteString
 decodeBase64 key s =


### PR DESCRIPTION
This PR aims to remove 2 dependencies:
  - ethereum
  - and hashes

by using Crypton to compute Keccak256 hashes.
We remove two exceptions cases : Keccak256OpenSslException and Keccak256OtherException.

This was a complete non-sense... A hash function is pure, defined for every input => And has ABSOLUTELY NO reproducible reason to fail. 
 
--

Before being merged, this PR requires:
- A benchmark to verify that gasing is still OK. Crypton is supposed to be a little bit slower than OpenSSL.
- And a replay to be sure Keccak256OpenSslException and Keccak256OtherException were never raised... But to be honest, I don't see why.