### PR TITLE
Make pandoc rendering in REPL optional

### DIFF
--- a/pact-repl/Pact/Core/Repl/BuiltinDocs.hs
+++ b/pact-repl/Pact/Core/Repl/BuiltinDocs.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE CPP #-}
 
 module Pact.Core.Repl.BuiltinDocs
   ( topLevelHasDocs
@@ -7,14 +8,17 @@ module Pact.Core.Repl.BuiltinDocs
   ) where
 
 import Data.Text (Text)
-import Control.Monad
+
 import Pact.Core.Syntax.ParseTree
 import Pact.Core.Names
 
 import qualified Data.Map.Strict as M
 import Pact.Core.Repl.BuiltinDocs.Internal
 
+#ifdef WITH_PANDOC_RENDERING
 import Text.Pandoc
+import Control.Monad
+#endif
 
 -- Only used for the REPL output.
 topLevelHasDocs :: TopLevel i -> Maybe Text
@@ -26,6 +30,8 @@ topLevelHasDocs _ = Nothing
 builtinDocs :: M.Map Text MarkdownDoc
 builtinDocs = $$mkBuiltinDocs
 
+
+#ifdef WITH_PANDOC_RENDERING
 renderBuiltinDoc :: Text -> IO (Either PandocError Text)
 renderBuiltinDoc = runIO . (readMarkdown readerOpts >=> writeANSI writerOpts)
 
@@ -38,3 +44,10 @@ writerOpts :: WriterOptions
 writerOpts = def
   { writerExtensions = pandocExtensions
   }
+
+#else
+
+renderBuiltinDoc :: Text -> IO (Either () Text)
+renderBuiltinDoc = pure . pure
+
+#endif

--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -41,6 +41,11 @@ flag with-native-tracing
   manual: True
   default: True
 
+flag with-pandoc-repl-rendering
+  description: Enable Markdown rendering within the REPL with Pandoc
+  manual: True
+  default: True
+
 library unsafe
   visibility: public
   hs-source-dirs: unsafe/src
@@ -320,6 +325,11 @@ library pact-repl
   if (flag(with-native-tracing) || flag(with-funcall-tracing))
     cpp-options: -DWITH_TRACING
 
+  if (flag(with-pandoc-repl-rendering))
+    cpp-options: -DWITH_PANDOC_RENDERING
+    build-depends:
+      pandoc
+
   exposed-modules:
     Pact.Core.Repl
     Pact.Core.Repl.Utils
@@ -344,7 +354,6 @@ library pact-repl
     , pact-tng
     , pact-tng:pact-crypto
     , filepath
-    , pandoc
 
 library pact-lsp
   import: pact-common


### PR DESCRIPTION
Pandoc is heavy and pulls a bunch of dependencies.
Just for coloring and doing nice ASCII rendering of Markdown.

In a lightweight build (for example in WASM) this is not desirable.

So we add a compilation flag to optionally disable Pandoc in REPL. 
The current default behavior (embedded Pandoc) is untouched, though. 